### PR TITLE
新增multiAggregate，能够对多个字段进行聚合操作

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,11 @@
 {
-    "name": "noprom/think-mongo-extend",
+    "name": "topthink/think-mongo",
     "description": "mongodb driver for thinkphp5",
     "license": "Apache-2.0",
     "authors": [
         {
             "name": "liu21st",
             "email": "liu21st@gmail.com"
-        },
-        {
-            "name": "noprom",
-            "email": "tyee.noprom@qq.com"
         }
     ],
     "require": {},

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "topthink/think-mongo",
+    "name": "noprom/think-mongo-extend",
     "description": "mongodb driver for thinkphp5",
     "license": "Apache-2.0",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
         {
             "name": "liu21st",
             "email": "liu21st@gmail.com"
+        },
+        {
+            "name": "noprom",
+            "email": "tyee.noprom@qq.com"
         }
     ],
     "require": {},

--- a/src/Query.php
+++ b/src/Query.php
@@ -492,6 +492,28 @@ class Query
     }
 
     /**
+     * 多聚合操作
+     *
+     * @param array $aggregate 聚合指令, 可以聚合多个参数, 如 ['sum' => 'field1', 'avg' => 'field2']
+     * @param array $groupBy 类似mysql里面的group字段, 可以传入多个字段, 如 ['field_a', 'field_b', 'field_c']
+     * @return array 查询结果
+     */
+    public function multiAggregate($aggregate, $groupBy)
+    {
+        $result = $this->cmd('multiAggregate', [$aggregate, $groupBy]);
+        $result = isset($result[0]['result']) ? $result[0]['result'] : [];
+        foreach ($result as &$row) {
+            if (isset($row['_id']) && !empty($row['_id'])) {
+                foreach ($row['_id'] as $k => $v) {
+                    $row[$k] = $v;
+                }
+                unset($row['_id']);
+            }
+        }
+        return $result;
+    }
+    
+    /**
      * 聚合查询
      * @access public
      * @param string $aggregate 聚合指令


### PR DESCRIPTION
新增multiAggregate，能够对多个字段进行聚合操作

用法:
```
$tableName = 'table_name';
Db::connect(config('mongo'))->name($tableName)
->multiAggregate(['sum' => 'field_sum', 'max' => 'study_date_year', 'min' => 'study_date_year'],
['tea_strength', 'tea_changes_per_day'];
# 可以产生如下类似mysql的查询效果
select `tea_strength`,  `tea_changes_per_day`, sum(`field_sum`), max(`study_date_year`), min(`study_date_year`) from `table_name` group by `tea_strength`, `tea_changes_per_day`;
```