### PR TITLE
优化multiAggregate操作，可以聚合多个参数

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,11 @@
 {
-    "name": "noprom/think-mongo-extend",
+    "name": "topthink/think-mongo",
     "description": "mongodb driver for thinkphp5",
     "license": "Apache-2.0",
     "authors": [
         {
             "name": "liu21st",
             "email": "liu21st@gmail.com"
-        },
-        {
-            "name": "noprom",
-            "email": "tyee.noprom@qq.com"
         }
     ],
     "require": {},

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "topthink/think-mongo",
+    "name": "noprom/think-mongo-extend",
     "description": "mongodb driver for thinkphp5",
     "license": "Apache-2.0",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
         {
             "name": "liu21st",
             "email": "liu21st@gmail.com"
+        },
+        {
+            "name": "noprom",
+            "email": "tyee.noprom@qq.com"
         }
     ],
     "require": {},

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -474,8 +474,15 @@ class Builder
             $groups['_id'][$field] = '$' . $field;
         }
 
-        foreach ($aggregate as $fun => $field) {
-            $groups[$field . '_' . $fun] = ['$' . $fun => '$' . $field];
+        // 支持对于一个聚合操作添加多个字段
+        foreach ($aggregate as $fun => $fields) {
+            foreach ($fields as $field) {
+                if ($fun == 'count') {
+                    $groups[$field . '_count'] = ['$sum' => 1];
+                } else {
+                    $groups[$field . '_' . $fun] = ['$' . $fun => '$' . $field];
+                }
+            }
         }
         $pipeline = [
             ['$match' => (object)$this->parseWhere($options['where'])],

--- a/src/Query.php
+++ b/src/Query.php
@@ -492,6 +492,28 @@ class Query
     }
 
     /**
+     * 多聚合操作
+     *
+     * @param array $aggregate 聚合指令, 可以聚合多个参数, 如 ['sum' => 'field1', 'avg' => 'field2']
+     * @param array $groupBy 类似mysql里面的group字段, 可以传入多个字段, 如 ['field_a', 'field_b', 'field_c']
+     * @return array 查询结果
+     */
+    public function multiAggregate($aggregate, $groupBy)
+    {
+        $result = $this->cmd('multiAggregate', [$aggregate, $groupBy]);
+        $result = isset($result[0]['result']) ? $result[0]['result'] : [];
+        foreach ($result as &$row) {
+            if (isset($row['_id']) && !empty($row['_id'])) {
+                foreach ($row['_id'] as $k => $v) {
+                    $row[$k] = $v;
+                }
+                unset($row['_id']);
+            }
+        }
+        return $result;
+    }
+    
+    /**
      * 聚合查询
      * @access public
      * @param string $aggregate 聚合指令

--- a/src/Query.php
+++ b/src/Query.php
@@ -494,7 +494,8 @@ class Query
     /**
      * 多聚合操作
      *
-     * @param array $aggregate 聚合指令, 可以聚合多个参数, 如 ['sum' => 'field1', 'avg' => 'field2']
+     * @param array $aggregate 聚合指令, 可以聚合多个参数
+     *              如 ['sum' => ['field1', 'field2'], 'avg' => ['field2', 'field3']]
      * @param array $groupBy 类似mysql里面的group字段, 可以传入多个字段, 如 ['field_a', 'field_b', 'field_c']
      * @return array 查询结果
      */


### PR DESCRIPTION
优化multiAggregate操作，对于一个聚合操作，支持传入多个字段

例子:
```
$tableName = 'table_name';
Db::connect(config('mongo'))->name($tableName)
->multiAggregate(['sum' => ['field_sum', 'field_sum_2'], 'max' => ['study_date_year', 'study_date_year2'], 'min' => ['study_date_year', 'study_date_year2']],
['tea_strength', 'tea_changes_per_day'];
```