### PR TITLE
fix authentication bug when specifying an authentication database

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -151,7 +151,7 @@ class Connection
             if ($config['pk_convert_id'] && '_id' == $config['pk']) {
                 $this->config['pk'] = 'id';
             }
-            $host = 'mongodb://' . ($config['username'] ? "{$config['username']}" : '') . ($config['password'] ? ":{$config['password']}@" : '') . $config['hostname'] . ($config['hostport'] ? ":{$config['hostport']}" : '') . '/' . ($config['database'] ? "{$config['database']}" : '');
+            $host = 'mongodb://' . ($config['username'] ? "{$config['username']}" : '') . ($config['password'] ? ":{$config['password']}@" : '') . $config['hostname'] . ($config['hostport'] ? ":{$config['hostport']}" : '');
             if ($config['debug']) {
                 $startTime = microtime(true);
             }


### PR DESCRIPTION
连接数据库时，uri中的database并不是实际提供数据的数据库，而是鉴权数据库，往往两个数据库是独立的。鉴权数据库默认是admin，可以在uri中指定鉴权数据库或在options中指定
```
[
    'db' => 'admin'
]
```
需要说明的是，在uri中指定鉴权数据库，优先级大于在options中指定，因此当鉴权数据库和实际提供数据的数据库不一样时，无论如何设置，都会鉴权失败。