### PR TITLE
修复“未定义数组下标: 1”

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -107,7 +107,7 @@ class Builder
 
             if (is_object($val)) {
                 $result[$item] = $val;
-            } elseif (isset($val[0]) && 'exp' == $val[0]) {
+            } elseif (isset($val[0]) && 'exp' === $val[0]) {
                 $result[$item] = $val[1];
             } elseif (is_null($val)) {
                 $result[$item] = 'NULL';


### PR DESCRIPTION
有如下代码:
$doc = [];
$doc['field1'] = 'name';
$doc['field2] = [0]; // 数组字段
$model->save($doc); 

经过调试：
执行到Builder.php里parseData函数出现了一个这样的判断：
`
elseif (isset($val[0]) && 'exp' == $val[0]) {
                $result[$item] = $val[1];
}
`
本意是根据数组第一个字段是否是字符串'exp'来判断是否进行exp表达式查询，
但是因为php奇怪的类型转换规则，如：
`
echo 'exp' == 0 ? true : false; // 打印true
`

所以如果$val是只有0的数组，则会进行到if内部，执行$val[1]，然后抛出“未定义数组下标: 1”的异常。

修复方法是把 `==` 修改为严格类型判断 `===`