### PR TITLE
queryStr 缺少 skip

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -470,6 +470,10 @@ class Connection
                     $this->queryStr .= '.sort(' . json_encode($options['sort']) . ')';
                 }
 
+                if (isset($options['skip'])) {
+                    $this->queryStr .= '.skip(' . $options['skip'] . ')';
+                }
+
                 if (isset($options['limit'])) {
                     $this->queryStr .= '.limit(' . $options['limit'] . ')';
                 }


### PR DESCRIPTION
通过getLastSql 获取的queryStr缺少skip