### PR TITLE
修复插入一维数组，数据错误的问题

### DIFF
--- a/src/builder/Mongo.php
+++ b/src/builder/Mongo.php
@@ -110,7 +110,7 @@ class Mongo
 
             if (is_object($val)) {
                 $result[$item] = $val;
-            } elseif (isset($val[0]) && 'exp' == $val[0]) {
+            } elseif (isset($val[0]) && 'exp' === $val[0]) {
                 $result[$item] = $val[1];
             } elseif (is_null($val)) {
                 $result[$item] = 'NULL';


### PR DESCRIPTION
一维数组第一个元素为数字0时，isset($val[0]) && 'exp' === $val[0]  这个判断会是true，parseData数据分析方法会把一维数组错误改为数组的第二个元素